### PR TITLE
Handle param names of maximum length that are not null-terminated

### DIFF
--- a/include/fcu_io.h
+++ b/include/fcu_io.h
@@ -7,6 +7,7 @@
 #define FCU_IO_MAVROSFLIGHT_ROS_H
 
 #include <map>
+#include <string>
 
 #include <ros/ros.h>
 
@@ -36,7 +37,7 @@ public:
 private:
 
   // mavrosflight callbacks
-  void paramCallback(char param_id[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN], float param_value, MAV_PARAM_TYPE param_type);
+  void paramCallback(std::string param_id, float param_value, MAV_PARAM_TYPE param_type);
   void heartbeatCallback();
   void imuCallback(double xacc, double yacc, double zacc, double xgyro, double ygyro, double zgyro);
   void servoOutputRawCallback(uint32_t time_usec, uint8_t port, uint16_t values[8]);

--- a/include/mavrosflight/mavrosflight.h
+++ b/include/mavrosflight/mavrosflight.h
@@ -44,7 +44,7 @@ public:
   void close();
 
   // callback functions
-  void register_param_value_callback(boost::function<void (char[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN], float, MAV_PARAM_TYPE)> f); //! \todo use boost::variant to handle multiple param types
+  void register_param_value_callback(boost::function<void (std::string, float, MAV_PARAM_TYPE)> f); //! \todo use boost::variant to handle multiple param types
   void unregister_param_value_callback();
 
   void register_heartbeat_callback(boost::function<void (void)> f);
@@ -164,7 +164,7 @@ private:
   mavlink_message_t msg_in_;
   mavlink_status_t status_in_;
 
-  boost::function<void (char[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN], float, MAV_PARAM_TYPE)> param_value_callback_;
+  boost::function<void (std::string, float, MAV_PARAM_TYPE)> param_value_callback_;
   boost::function<void (void)> heartbeat_callback_;
   boost::function<void (double, double, double, double, double, double)> imu_callback_;
   boost::function<void (uint32_t, uint8_t, uint16_t[8])> servo_output_raw_callback_;

--- a/src/fcu_io.cpp
+++ b/src/fcu_io.cpp
@@ -88,7 +88,7 @@ bool fcuIO::paramWriteSrvCallback(std_srvs::Empty::Request &req, std_srvs::Empty
   return true;
 }
 
-void fcuIO::paramCallback(char param_id[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN], float param_value, MAV_PARAM_TYPE param_type)
+void fcuIO::paramCallback(std::string param_id, float param_value, MAV_PARAM_TYPE param_type)
 {
   bool have_uint(false);
   uint32_t uint_value;
@@ -132,11 +132,11 @@ void fcuIO::paramCallback(char param_id[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_L
   }
 
   if (have_uint)
-    ROS_INFO("Got parameter %s with value %u", param_id, uint_value);
+    ROS_INFO("Got parameter %s with value %u", param_id.c_str(), uint_value);
   else if (have_int)
-    ROS_INFO("Got parameter %s with value %d", param_id, int_value);
+    ROS_INFO("Got parameter %s with value %d", param_id.c_str(), int_value);
   else if (have_float)
-    ROS_INFO("Got parameter %s with value %f", param_id, param_value);
+    ROS_INFO("Got parameter %s with value %f", param_id.c_str(), param_value);
 }
 
 void fcuIO::heartbeatCallback()

--- a/src/mavrosflight/mavrosflight.cpp
+++ b/src/mavrosflight/mavrosflight.cpp
@@ -60,7 +60,7 @@ void MavROSflight::close()
   }
 }
 
-void MavROSflight::register_param_value_callback(boost::function<void (char[], float, MAV_PARAM_TYPE)> f)
+void MavROSflight::register_param_value_callback(boost::function<void (std::string, float, MAV_PARAM_TYPE)> f)
 {
   param_value_callback_ = f;
 }
@@ -297,7 +297,9 @@ void MavROSflight::handle_message()
     {
       mavlink_param_value_t msg;
       mavlink_msg_param_value_decode(&msg_in_, &msg);
-      param_value_callback_(msg.param_id, msg.param_value, (MAV_PARAM_TYPE) msg.param_type);
+      param_value_callback_(std::string(msg.param_id, MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN),
+                            msg.param_value,
+                            (MAV_PARAM_TYPE) msg.param_type);
     }
     break;
   case MAVLINK_MSG_ID_HEARTBEAT:


### PR DESCRIPTION
Mavlink parameter names are limited to 16 characters. If the name is shorter than that, the string is null terminated (standard c-style string). If the name is exactly 16 characters, then the null termination character (`'\0'`) is truncated so the name still fits in a 16-byte buffer.

This pull request stops the code from reading off the end of the buffer when the name is not null-terminated.
