### PR TITLE
Accel calibration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(mavrosflight
   src/mavrosflight/time_manager.cpp
   src/mavrosflight/sensors/differential_pressure.cpp
   src/mavrosflight/sensors/imu.cpp
+  src/mavrosflight/sensors/baro.cpp
 )
 add_dependencies(mavrosflight ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(mavrosflight

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,9 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
   std_msgs
+  cmake_modules
 )
-
+find_package(Eigen REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system thread)
 
 ###################################

--- a/include/fcu_io.h
+++ b/include/fcu_io.h
@@ -65,7 +65,7 @@ private:
   bool paramGetSrvCallback(fcu_io::ParamGet::Request &req, fcu_io::ParamGet::Response &res);
   bool paramSetSrvCallback(fcu_io::ParamSet::Request &req, fcu_io::ParamSet::Response &res);
   bool paramWriteSrvCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
-  bool calibrateIMUCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
+  bool calibrateImuTempSrvCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
 
   // helpers
   template<class T> inline T saturate(T value, T min, T max)

--- a/include/fcu_io.h
+++ b/include/fcu_io.h
@@ -65,6 +65,7 @@ private:
   bool paramGetSrvCallback(fcu_io::ParamGet::Request &req, fcu_io::ParamGet::Response &res);
   bool paramSetSrvCallback(fcu_io::ParamSet::Request &req, fcu_io::ParamSet::Response &res);
   bool paramWriteSrvCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
+  bool calibrateIMUCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
 
   // helpers
   template<class T> inline T saturate(T value, T min, T max)
@@ -88,6 +89,7 @@ private:
   ros::ServiceServer param_get_srv_;
   ros::ServiceServer param_set_srv_;
   ros::ServiceServer param_write_srv_;
+  ros::ServiceServer imu_calibrate_srv_;
 
   mavrosflight::MavROSflight *mavrosflight_;
   mavrosflight::sensors::DifferentialPressure diff_pressure_;

--- a/include/fcu_io.h
+++ b/include/fcu_io.h
@@ -89,6 +89,9 @@ private:
   ros::ServiceServer param_write_srv_;
 
   mavrosflight::MavROSflight* mavrosflight_;
+
+  double start_time_;
+  double temperature_;
 };
 
 } // namespace fcu_io

--- a/include/fcu_io.h
+++ b/include/fcu_io.h
@@ -33,8 +33,8 @@ namespace fcu_io
 {
 
 class fcuIO :
-    public mavrosflight::MavlinkListenerInterface,
-    public mavrosflight::ParamListenerInterface
+  public mavrosflight::MavlinkListenerInterface,
+  public mavrosflight::ParamListenerInterface
 {
 public:
   fcuIO();
@@ -89,7 +89,7 @@ private:
   ros::ServiceServer param_set_srv_;
   ros::ServiceServer param_write_srv_;
 
-  mavrosflight::MavROSflight* mavrosflight_;
+  mavrosflight::MavROSflight *mavrosflight_;
   mavrosflight::sensors::DifferentialPressure diff_pressure_;
   mavrosflight::sensors::Imu imu_;
   mavrosflight::sensors::Baro baro_;

--- a/include/fcu_io.h
+++ b/include/fcu_io.h
@@ -54,6 +54,7 @@ private:
   void handle_servo_output_raw_msg(const mavlink_message_t &msg);
   void handle_rc_channels_raw_msg(const mavlink_message_t &msg);
   void handle_diff_pressure_msg(const mavlink_message_t &msg);
+  void handle_small_baro_msg(const mavlink_message_t &msg);
   void handle_named_value_int_msg(const mavlink_message_t &msg);
   void handle_named_value_float_msg(const mavlink_message_t &msg);
 
@@ -79,6 +80,7 @@ private:
   ros::Publisher rc_raw_pub_;
   ros::Publisher diff_pressure_pub_;
   ros::Publisher temperature_pub_;
+  ros::Publisher baro_pub_;
   std::map<std::string, ros::Publisher> named_value_int_pubs_;
   std::map<std::string, ros::Publisher> named_value_float_pubs_;
 

--- a/include/fcu_io.h
+++ b/include/fcu_io.h
@@ -90,14 +90,9 @@ private:
   ros::ServiceServer param_write_srv_;
 
   mavrosflight::MavROSflight* mavrosflight_;
-//<<<<<<< HEAD
-
-//  double start_time_;
-//  double temperature_;
-//=======
   mavrosflight::sensors::DifferentialPressure diff_pressure_;
   mavrosflight::sensors::Imu imu_;
-//>>>>>>> master
+  mavrosflight::sensors::Baro baro_;
 };
 
 } // namespace fcu_io

--- a/include/fcu_io.h
+++ b/include/fcu_io.h
@@ -50,6 +50,7 @@ private:
 
   // handle mavlink messages
   void handle_heartbeat_msg();
+  void handle_command_ack_msg(const mavlink_message_t &msg);
   void handle_small_imu_msg(const mavlink_message_t &msg);
   void handle_servo_output_raw_msg(const mavlink_message_t &msg);
   void handle_rc_channels_raw_msg(const mavlink_message_t &msg);
@@ -65,6 +66,7 @@ private:
   bool paramGetSrvCallback(fcu_io::ParamGet::Request &req, fcu_io::ParamGet::Response &res);
   bool paramSetSrvCallback(fcu_io::ParamSet::Request &req, fcu_io::ParamSet::Response &res);
   bool paramWriteSrvCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
+  bool calibrateImuBiasSrvCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
   bool calibrateImuTempSrvCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
 
   // helpers
@@ -89,7 +91,8 @@ private:
   ros::ServiceServer param_get_srv_;
   ros::ServiceServer param_set_srv_;
   ros::ServiceServer param_write_srv_;
-  ros::ServiceServer imu_calibrate_srv_;
+  ros::ServiceServer imu_calibrate_bias_srv_;
+  ros::ServiceServer imu_calibrate_temp_srv_;
 
   mavrosflight::MavROSflight *mavrosflight_;
   mavrosflight::sensors::DifferentialPressure diff_pressure_;

--- a/include/mavrosflight/mavlink_serial.h
+++ b/include/mavrosflight/mavlink_serial.h
@@ -90,7 +90,7 @@ private:
   /**
    * \brief Convenience typedef for mutex lock
    */
-  typedef boost::mutex::scoped_lock mutex_lock;
+  typedef boost::lock_guard<boost::recursive_mutex> mutex_lock;
 
   //===========================================================================
   // methods
@@ -135,7 +135,7 @@ private:
   boost::asio::io_service io_service_; //!< boost io service provider
   boost::asio::serial_port serial_port_; //!< boost serial port object
   boost::thread io_thread_; //!< thread on which the io service runs
-  boost::mutex mutex_; //!< mutex for threadsafe operation
+  boost::recursive_mutex mutex_; //!< mutex for threadsafe operation
 
   uint8_t sysid_;
   uint8_t compid_;

--- a/include/mavrosflight/mavlink_serial.h
+++ b/include/mavrosflight/mavlink_serial.h
@@ -13,6 +13,7 @@
 #include <boost/asio.hpp>
 #include <boost/thread.hpp>
 #include <boost/function.hpp>
+#include <boost/lockfree/spsc_queue.hpp>
 
 #include <list>
 #include <string>
@@ -145,7 +146,7 @@ private:
   mavlink_message_t msg_in_;
   mavlink_status_t status_in_;
 
-  std::list<WriteBuffer*> write_queue_; //!< queue of buffers to be written to the serial port
+  boost::lockfree::spsc_queue<WriteBuffer*> write_queue_;
   bool write_in_progress_; //!< flag for whether async_write is already running
 };
 

--- a/include/mavrosflight/mavlink_serial.h
+++ b/include/mavrosflight/mavlink_serial.h
@@ -13,7 +13,6 @@
 #include <boost/asio.hpp>
 #include <boost/thread.hpp>
 #include <boost/function.hpp>
-#include <boost/lockfree/spsc_queue.hpp>
 
 #include <list>
 #include <string>
@@ -146,7 +145,7 @@ private:
   mavlink_message_t msg_in_;
   mavlink_status_t status_in_;
 
-  boost::lockfree::spsc_queue<WriteBuffer*> write_queue_;
+  std::list<WriteBuffer*> write_queue_; //!< queue of buffers to be written to the serial port
   bool write_in_progress_; //!< flag for whether async_write is already running
 };
 

--- a/include/mavrosflight/mavrosflight.h
+++ b/include/mavrosflight/mavrosflight.h
@@ -16,6 +16,7 @@
 
 #include <mavrosflight/sensors/differential_pressure.h>
 #include <mavrosflight/sensors/imu.h>
+#include <mavrosflight/sensors/baro.h>
 
 #include <boost/function.hpp>
 

--- a/include/mavrosflight/param.h
+++ b/include/mavrosflight/param.h
@@ -37,6 +37,7 @@ private:
   void setFromRawValue(float raw_value);
   float getRawValue();
   float getRawValue(double value);
+  double getCastValue(double value);
 
   template<typename T>
   double fromRawValue(float value)
@@ -50,6 +51,12 @@ private:
   {
     T t_value = (T) value;
     return *(float*) &t_value;
+  }
+
+  template<typename T>
+  double toCastValue(double value)
+  {
+    return (double) ((T) value);
   }
 
   MavlinkSerial *serial_;

--- a/include/mavrosflight/sensors/baro.h
+++ b/include/mavrosflight/sensors/baro.h
@@ -1,0 +1,55 @@
+/**
+ * \file imu.h
+ * \author James Jackson <superjax08@gmail.com>
+ */
+
+#ifndef MAVROSFLIGHT_SENSORS_BARO_H
+#define MAVROSFLIGHT_SENSORS_BARO_H
+
+#include <mavrosflight/mavlink_bridge.h>
+
+namespace mavrosflight
+{
+namespace sensors
+{
+
+/**
+ * \brief Barometer sensor class
+ */
+class Baro
+{
+public:
+
+  Baro(double alpha, double ground, int settling_count, int calibration_count);
+  Baro();
+
+  // The Alpha in the LPF of the barometer
+  double alt_alpha_;
+
+  // The position of the ground in the barometer
+  double alt_ground_;
+
+  /**
+   * \brief Get corrected measurement values
+   * \param msg The raw barometer message
+   * \param[out] alt The altitude in meters
+   * \return True if the measurement is valid
+   */
+  bool correct(mavlink_small_baro_t msg, double *alt);
+
+private:
+  // calibration variables
+  int calibration_counter_;
+  double calibration_sum_;
+  int settling_count_; // settle for a second or so
+  int calibration_count_;
+
+  // offsets and filters
+  double prev_alt_;
+
+};
+
+} // namespace sensors
+} // namespace mavrosflight
+
+#endif // MAVROSFLIGHT_SENSORS_IMU_H

--- a/include/mavrosflight/sensors/imu.h
+++ b/include/mavrosflight/sensors/imu.h
@@ -46,6 +46,15 @@ public:
   bool correct(mavlink_small_imu_t msg,
                double *xacc, double *yacc, double *zacc, double *xgyro, double *ygyro, double *zgyro, double *temperature);
 
+  /// These are the publicly available versions of the accel calibration
+  /// The const stuff is to make it read-only
+  const double xm() const {return x_[0](0);}
+  const double ym() const {return x_[1](0);}
+  const double zm() const {return x_[2](0);}
+  const double xb() const {return x_[0](1);}
+  const double yb() const {return x_[1](1);}
+  const double zb() const {return x_[2](1);}
+
 private:
   //! \todo explicitly compute these so it's clear where they come from
   static const double ACCEL_SCALE = 0.002349;

--- a/include/mavrosflight/sensors/imu.h
+++ b/include/mavrosflight/sensors/imu.h
@@ -60,6 +60,7 @@ private:
   static const double ACCEL_SCALE = 0.002349;
   static const double GYRO_SCALE = 0.004256;
   Eigen::Vector2d x_[3];
+  double calibration_time_;
 };
 
 } // namespace sensors

--- a/include/mavrosflight/sensors/imu.h
+++ b/include/mavrosflight/sensors/imu.h
@@ -23,6 +23,8 @@ public:
 
   Imu();
 
+  bool calibrated;
+
   /**
    * \brief Calibrate the IMU for temperature and bias compensation
    * \param msg The raw IMU message

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>cmake_modules</depend>
 
   <build_depend>message_generation</build_depend>
 

--- a/src/fcu_io.cpp
+++ b/src/fcu_io.cpp
@@ -90,12 +90,8 @@ void fcuIO::handle_mavlink_message(const mavlink_message_t &msg)
   case MAVLINK_MSG_ID_SMALL_BARO:
     handle_small_baro_msg(msg);
     break;
-  case MAVLINK_MSG_ID_TIMESYNC: // <-- This is handled by the time_manager
-    break;
-  case MAVLINK_MSG_ID_PARAM_VALUE: // <-- This is handled by the param_manager
-    break;
   default:
-    ROS_ERROR("fcu_io:Got unsupported message ID %d", msg.msgid);
+    ROS_DEBUG("fcu_io: Got unhandled mavlink message ID %d", msg.msgid);
     break;
   }
 }

--- a/src/fcu_io.cpp
+++ b/src/fcu_io.cpp
@@ -36,7 +36,7 @@ fcuIO::fcuIO()
 
   ros::NodeHandle nh_private("~");
   std::string port = nh_private.param<std::string>("port", "/dev/ttyUSB0");
-  int baud_rate = nh_private.param<int>("baud_rate", 115200);
+  int baud_rate = nh_private.param<int>("baud_rate", 921600);
 
 
   try

--- a/src/fcu_io.cpp
+++ b/src/fcu_io.cpp
@@ -32,7 +32,7 @@ fcuIO::fcuIO()
   param_get_srv_ = nh.advertiseService("param_get", &fcuIO::paramGetSrvCallback, this);
   param_set_srv_ = nh.advertiseService("param_set", &fcuIO::paramSetSrvCallback, this);
   param_write_srv_ = nh.advertiseService("param_write", &fcuIO::paramWriteSrvCallback, this);
-  imu_calibrate_srv_ = nh.advertiseService("calibrate_imu", &fcuIO::calibrateIMUCallback, this);
+  imu_calibrate_srv_ = nh.advertiseService("calibrate_imu_temp", &fcuIO::calibrateImuTempSrvCallback, this);
 
   ros::NodeHandle nh_private("~");
   std::string port = nh_private.param<std::string>("port", "/dev/ttyUSB0");
@@ -345,7 +345,7 @@ bool fcuIO::paramWriteSrvCallback(std_srvs::Trigger::Request &req, std_srvs::Tri
   return true;
 }
 
-bool fcuIO::calibrateIMUCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
+bool fcuIO::calibrateImuTempSrvCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
 {
   // tell the IMU to start a temperature calibration
   imu_.start_temp_calibration();

--- a/src/fcu_io.cpp
+++ b/src/fcu_io.cpp
@@ -174,9 +174,9 @@ void fcuIO::handle_small_imu_msg(const mavlink_message_t &msg)
       mavrosflight_->param.set_param_value("ACC_X_TEMP_COMP", 1000.0*imu_.xm());
       mavrosflight_->param.set_param_value("ACC_Y_TEMP_COMP", 1000.0*imu_.ym());
       mavrosflight_->param.set_param_value("ACC_Z_TEMP_COMP", 1000.0*imu_.zm());
-      mavrosflight_->param.set_param_value("ACC_X_BIAS", 1000.0*imu_.xb());
-      mavrosflight_->param.set_param_value("ACC_Y_BIAS", 1000.0*imu_.yb());
-      mavrosflight_->param.set_param_value("ACC_Z_BIAS", 1000.0*imu_.zb());
+      mavrosflight_->param.set_param_value("ACC_X_BIAS", imu_.xb());
+      mavrosflight_->param.set_param_value("ACC_Y_BIAS", imu_.yb());
+      mavrosflight_->param.set_param_value("ACC_Z_BIAS", imu_.zb());
 
       ROS_WARN("Write params to save new temperature calibration!");
     }
@@ -382,9 +382,17 @@ bool fcuIO::calibrateImuBiasSrvCallback(std_srvs::Trigger::Request &req, std_srv
 
 bool fcuIO::calibrateImuTempSrvCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
 {
+  // First, reset the previous calibration
+  mavrosflight_->param.set_param_value("ACC_X_TEMP_COMP", 0);
+  mavrosflight_->param.set_param_value("ACC_Y_TEMP_COMP", 0);
+  mavrosflight_->param.set_param_value("ACC_Z_TEMP_COMP", 0);
+  mavrosflight_->param.set_param_value("ACC_X_BIAS", 0);
+  mavrosflight_->param.set_param_value("ACC_Y_BIAS", 0);
+  mavrosflight_->param.set_param_value("ACC_Z_BIAS", 0);
+
   // tell the IMU to start a temperature calibration
   imu_.start_temp_calibration();
-  ROS_INFO("IMU temperature calibration started");
+  ROS_WARN("IMU temperature calibration started");
 
   res.success = true;
   return true;

--- a/src/fcu_io.cpp
+++ b/src/fcu_io.cpp
@@ -152,7 +152,6 @@ void fcuIO::handle_small_imu_msg(const mavlink_message_t &msg)
       ROS_INFO("accel parameters found\n xm = %f, ym = %f, zm = %f xb = %f yb = %f, zb = %f",
                imu_.xm(),imu_.ym(),imu_.zm(),imu_.xb(),imu_.yb(),imu_.zb());
         // calibration is done, send params to the param server and save them
-        /// DOING IT THIS WAY ENSURES THAT FCU_IO WILL CRASH -- I THINK WE ARE OVERFLOWING A BUFFER SOMEWHERE
         mavrosflight_->param.set_param_value("ACC_X_TEMP_COMP", 1000.0*imu_.xm());
         mavrosflight_->param.set_param_value("ACC_Y_TEMP_COMP", 1000.0*imu_.ym());
         mavrosflight_->param.set_param_value("ACC_Z_TEMP_COMP", 1000.0*imu_.zm());

--- a/src/fcu_io.cpp
+++ b/src/fcu_io.cpp
@@ -355,6 +355,7 @@ bool fcuIO::calibrateIMUCallback(std_srvs::Trigger::Request &req, std_srvs::Trig
   // tell the IMU to calibrate itself
   imu_.calibrated = false;
   res.success = true;
+  return true;
 }
 
 } // namespace fcu_io

--- a/src/fcu_io_node.cpp
+++ b/src/fcu_io_node.cpp
@@ -8,7 +8,7 @@
 #include <ros/ros.h>
 #include "fcu_io.h"
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
   ros::init(argc, argv, "fcu_io_node");
   fcu_io::fcuIO fcu_io;

--- a/src/mavrosflight/mavlink_serial.cpp
+++ b/src/mavrosflight/mavlink_serial.cpp
@@ -11,6 +11,10 @@
 #include <boost/thread.hpp>
 #include <ros/ros.h>
 
+#include <iostream>
+
+using namespace std;
+
 namespace mavrosflight
 {
 
@@ -135,7 +139,7 @@ void MavlinkSerial::send_message(const mavlink_message_t &msg)
   WriteBuffer *buffer = new WriteBuffer();
   buffer->len = mavlink_msg_to_send_buffer(buffer->data, &msg);
   assert(buffer->len <= MAVLINK_MAX_PACKET_LEN); //! \todo Do something less catastrophic here
-
+  // is there supposed to be a condition here?
   {
     mutex_lock lock(mutex_);
     write_queue_.push_back(buffer);
@@ -152,7 +156,6 @@ void MavlinkSerial::do_async_write(bool check_write_state)
   mutex_lock lock(mutex_);
   if (write_queue_.empty())
     return;
-
   write_in_progress_ = true;
   WriteBuffer *buffer = write_queue_.front();
   serial_port_.async_write_some(

--- a/src/mavrosflight/param.cpp
+++ b/src/mavrosflight/param.cpp
@@ -50,7 +50,7 @@ void Param::requestSet(double value, mavlink_message_t *msg)
 {
   if (value != value_)
   {
-    new_value_ = value;
+    new_value_ = getCastValue(value);
     expected_raw_value_ = getRawValue(new_value_);
 
     mavlink_msg_param_set_pack(1, 50, msg,
@@ -149,6 +149,38 @@ float Param::getRawValue(double value)
   }
 
   return raw_value;
+}
+
+double Param::getCastValue(double value)
+{
+  double cast_value;
+
+  switch (type_)
+  {
+  case MAV_PARAM_TYPE_INT8:
+    cast_value = toCastValue<int8_t>(value);
+    break;
+  case MAV_PARAM_TYPE_INT16:
+    cast_value = toCastValue<int16_t>(value);
+    break;
+  case MAV_PARAM_TYPE_INT32:
+    cast_value = toCastValue<int32_t>(value);
+    break;
+  case MAV_PARAM_TYPE_UINT8:
+    cast_value = toCastValue<uint8_t>(value);
+    break;
+  case MAV_PARAM_TYPE_UINT16:
+    cast_value = toCastValue<uint16_t>(value);
+    break;
+  case MAV_PARAM_TYPE_UINT32:
+    cast_value = toCastValue<uint32_t>(value);
+    break;
+  case MAV_PARAM_TYPE_REAL32:
+    cast_value = toCastValue<float>(value);
+    break;
+  }
+
+  return cast_value;
 }
 
 } // namespace mavrosflight

--- a/src/mavrosflight/sensors/baro.cpp
+++ b/src/mavrosflight/sensors/baro.cpp
@@ -1,0 +1,70 @@
+/**
+ * \file baro.cpp
+ * \author James Jackson <superjax08@gmail.com>
+ */
+
+#include <mavrosflight/sensors/baro.h>
+#include <ros/ros.h>
+
+namespace mavrosflight
+{
+namespace sensors
+{
+
+Baro::Baro(double alpha, double ground, int settling_count, int calibration_count)
+{
+  Baro();
+  alt_alpha_ = alpha;
+  alt_ground_ = ground;
+  settling_count_ = settling_count; // settle for a second or so
+  calibration_count_ = calibration_count;
+}
+
+Baro::Baro()
+{
+  alt_alpha_ = 0.3;
+  alt_ground_ = 0.0;
+  settling_count_ = 20; // settle for a second or so
+  calibration_count_ = 20;
+  calibration_counter_ = 0;
+  calibration_sum_ = 0;
+  prev_alt_ = 0.0;
+}
+
+bool Baro::correct(mavlink_small_baro_t baro, double *alt)
+{
+  double pressure = baro.pressure;
+  double temperature = baro.temperature;
+
+  if( calibration_counter_ > calibration_count_ + settling_count_)
+  {
+    double alt_tmp = (1.0f - pow(pressure/101325.0f, 0.190295f)) * 4430.0f; // in meters
+
+    // offset calculated ground altitude
+    alt_tmp -= alt_ground_;
+
+    // LPF measurements
+    *alt = alt_alpha_*alt_tmp + (1.0 - alt_alpha_)*prev_alt_;
+    prev_alt_ = *alt;
+  }
+  if (calibration_counter_ < settling_count_)
+  {
+    calibration_counter_++;
+  }
+  else if (calibration_counter_ < settling_count_ + calibration_count_)
+  {
+    double measurement = (1.0f - pow(pressure/101325.0f, 0.190295f)) * 4430.0f;
+    calibration_sum_ += measurement;
+    calibration_counter_++;
+  }
+  else if(calibration_counter_ == settling_count_ + calibration_count_)
+  {
+    alt_ground_ = calibration_sum_/calibration_count_;
+    ROS_INFO_STREAM("BARO CALIBRATED " << alt_ground_ << " meters above sea level");
+    calibration_counter_++;
+  }
+}
+
+
+} // namespace sensors
+} // namespace mavrosflight

--- a/src/mavrosflight/sensors/imu.cpp
+++ b/src/mavrosflight/sensors/imu.cpp
@@ -28,8 +28,8 @@ bool Imu::calibrate(mavlink_small_imu_t msg)
   // read temperature of accel chip for temperature compensation calibration
   double temperature = ((double)msg.temperature/340.0 + 36.53);
 
-  static double calibration_time = 5.0; // seconds to record data for temperature compensation
-  static double deltaT = 0.0005; // number of degrees required for a temperature calibration
+  static double calibration_time = 10.0; // seconds to record data for temperature compensation
+  static double deltaT = 1.0; // number of degrees required for a temperature calibration
 
   static double Tmin = 1000; // minimum temperature seen
   static double Tmax = -1000; // maximum temperature seen

--- a/src/mavrosflight/sensors/imu.cpp
+++ b/src/mavrosflight/sensors/imu.cpp
@@ -29,7 +29,7 @@ bool Imu::calibrate(mavlink_small_imu_t msg)
   double temperature = ((double)msg.temperature/340.0 + 36.53);
 
   static double calibration_time = 5.0; // seconds to record data for temperature compensation
-  static double deltaT = 1.0; // number of degrees required for a temperature calibration
+  static double deltaT = 0.0005; // number of degrees required for a temperature calibration
 
   static double Tmin = 1000; // minimum temperature seen
   static double Tmax = -1000; // maximum temperature seen

--- a/src/mavrosflight/sensors/imu.cpp
+++ b/src/mavrosflight/sensors/imu.cpp
@@ -20,6 +20,7 @@ Imu::Imu()
   x_[0] << 0, 0;
   x_[1] << 0, 0;
   x_[2] << 0, 0;
+  calibrated = false;
 }
 
 bool Imu::calibrate(mavlink_small_imu_t msg)
@@ -37,7 +38,6 @@ bool Imu::calibrate(mavlink_small_imu_t msg)
   static std::deque<Eigen::Vector3d> A(0);
   static std::deque<double> B(0);
   static bool first_time = true;
-  static bool calibrated = false;
 
   static double start_time = 0;
 

--- a/src/mavrosflight/sensors/imu.cpp
+++ b/src/mavrosflight/sensors/imu.cpp
@@ -20,7 +20,7 @@ Imu::Imu()
   x_[0] << 0, 0;
   x_[1] << 0, 0;
   x_[2] << 0, 0;
-  calibrated = false;
+  calibrated = true;
 }
 
 bool Imu::calibrate(mavlink_small_imu_t msg)
@@ -91,7 +91,6 @@ bool Imu::calibrate(mavlink_small_imu_t msg)
 
       // Perform Least-Squares on the data
       x_[i] = Amat.jacobiSvd(Eigen::ComputeFullU | Eigen::ComputeFullV).solve(Bmat);
-      ROS_INFO_STREAM("x" << i <<" = " << x_[i]); // <-- These should get saved in the parameter server
     }
     calibrated = true;
   }
@@ -101,10 +100,9 @@ bool Imu::calibrate(mavlink_small_imu_t msg)
 bool Imu::correct(mavlink_small_imu_t msg,
                   double *xacc, double *yacc, double *zacc, double *xgyro, double *ygyro, double *zgyro, double *temp)
 {
-  double temperature = ((double)msg.temperature/340.0 + 36.53);
-  *xacc = (msg.xacc - (temperature)*x_[0](0) - x_[0](1)) * ACCEL_SCALE;
-  *yacc = (msg.yacc - (temperature)*x_[1](0) - x_[1](1)) * ACCEL_SCALE;
-  *zacc = (msg.zacc - (temperature)*x_[2](0) - x_[2](1)) * ACCEL_SCALE;
+  *xacc = msg.xacc * ACCEL_SCALE;
+  *yacc = msg.yacc * ACCEL_SCALE;
+  *zacc = msg.zacc * ACCEL_SCALE;
 
   *xgyro = msg.xgyro * GYRO_SCALE;
   *ygyro = msg.ygyro * GYRO_SCALE;


### PR DESCRIPTION
Supersedes #22

There are some things i would like to fix, but I need your help @dpkoch.

I think we should save the calibration parameters from the IMU to a file.  They are currently saved as a private member of the Imu class, and they are solved for on [line 94 of imu.cpp](https://github.com/BYU-MAGICC/fcu_io2/blob/accel_calibration/src/mavrosflight/sensors/imu.cpp#L93).  I think it should be pretty easy to save off the values in `x_` to the parameter handler, but I'm not sure how to get that working.  These same parameters should be loaded on the constructor for the `Imu` class.  That is in [lines 20-22 of imu.cpp](https://github.com/BYU-MAGICC/fcu_io2/blob/accel_calibration/src/mavrosflight/sensors/imu.cpp#L20-22).  Do you think that's possible?

After those things are going, then I think we should make calibrating the IMU a service call to `fcu_io`.  That way, it is only called when someone wants it called.

 I also got the barometer into it's own class, it has a `correct` function and the whole thing.
