### PR TITLE
Accel calibration float

### DIFF
--- a/include/mavrosflight/sensors/imu.h
+++ b/include/mavrosflight/sensors/imu.h
@@ -67,10 +67,6 @@ public:
   const double zb() const { return x_[2](1); }
 
 private:
-  //! \todo explicitly compute these so it's clear where they come from
-  static const double ACCEL_SCALE = 0.002349;
-  static const double GYRO_SCALE = 0.004256;
-
   Eigen::Vector2d x_[3];
 
   bool calibrating_; //!< whether a temperature calibration is in progress

--- a/include/mavrosflight/sensors/imu.h
+++ b/include/mavrosflight/sensors/imu.h
@@ -77,8 +77,8 @@ private:
   bool first_time_; //!< waiting for first measurement for calibration
   double start_time_; //!< timestamp of first calibration measurement
   int measurement_throttle_;
-  std::deque<Eigen::Vector3d> A_;
-  std::deque<double> B_;
+  std::deque<double> A_;
+  std::deque<Eigen::Vector3d> B_;
 };
 
 } // namespace sensors

--- a/src/fcu_io.cpp
+++ b/src/fcu_io.cpp
@@ -171,9 +171,9 @@ void fcuIO::handle_small_imu_msg(const mavlink_message_t &msg)
                imu_.xm(),imu_.ym(),imu_.zm(),imu_.xb(),imu_.yb(),imu_.zb());
 
       // calibration is done, send params to the param server
-      mavrosflight_->param.set_param_value("ACC_X_TEMP_COMP", 1000.0*imu_.xm());
-      mavrosflight_->param.set_param_value("ACC_Y_TEMP_COMP", 1000.0*imu_.ym());
-      mavrosflight_->param.set_param_value("ACC_Z_TEMP_COMP", 1000.0*imu_.zm());
+      mavrosflight_->param.set_param_value("ACC_X_TEMP_COMP", imu_.xm());
+      mavrosflight_->param.set_param_value("ACC_Y_TEMP_COMP", imu_.ym());
+      mavrosflight_->param.set_param_value("ACC_Z_TEMP_COMP", imu_.zm());
       mavrosflight_->param.set_param_value("ACC_X_BIAS", imu_.xb());
       mavrosflight_->param.set_param_value("ACC_Y_BIAS", imu_.yb());
       mavrosflight_->param.set_param_value("ACC_Z_BIAS", imu_.zb());

--- a/src/mavrosflight/sensors/imu.cpp
+++ b/src/mavrosflight/sensors/imu.cpp
@@ -42,9 +42,6 @@ void Imu::start_temp_calibration()
 
 bool Imu::calibrate_temp(mavlink_small_imu_t msg)
 {
-  // read temperature of accel chip for temperature compensation calibration
-  double temperature = ((double)msg.temperature/340.0 + 36.53);
-
   if (first_time_)
   {
     first_time_ = false;
@@ -59,16 +56,16 @@ bool Imu::calibrate_temp(mavlink_small_imu_t msg)
     if (measurement_throttle_ > 20)
     {
       Eigen::Vector3d measurement;
-      measurement << msg.xacc, msg.yacc, msg.zacc - 4096; //! \todo need a better way to know the z-axis offset
+      measurement << msg.xacc, msg.yacc, msg.zacc - 9.60665; //! \todo need a better way to know the z-axis offset
       A_.push_back(measurement);
       B_.push_back(msg.temperature);
-      if (temperature < Tmin_)
+      if (msg.temperature < Tmin_)
       {
-        Tmin_ = temperature;
+        Tmin_ = msg.temperature;
       }
-      if (temperature > Tmax_)
+      if (msg.temperature > Tmax_)
       {
-        Tmax_ = temperature;
+        Tmax_ = msg.temperature;
       }
       measurement_throttle_ = 0;
     }
@@ -113,15 +110,15 @@ bool Imu::calibrate_temp(mavlink_small_imu_t msg)
 bool Imu::correct(mavlink_small_imu_t msg,
                   double *xacc, double *yacc, double *zacc, double *xgyro, double *ygyro, double *zgyro, double *temp)
 {
-  *xacc = msg.xacc * ACCEL_SCALE;
-  *yacc = msg.yacc * ACCEL_SCALE;
-  *zacc = msg.zacc * ACCEL_SCALE;
+  *xacc = msg.xacc;
+  *yacc = msg.yacc;
+  *zacc = msg.zacc;
 
-  *xgyro = msg.xgyro * GYRO_SCALE;
-  *ygyro = msg.ygyro * GYRO_SCALE;
-  *zgyro = msg.zgyro * GYRO_SCALE;
+  *xgyro = msg.xgyro;
+  *ygyro = msg.ygyro;
+  *zgyro = msg.zgyro;
 
-  *temp = msg.temperature/340.0 + 36.53;
+  *temp = msg.temperature;
   return true;
 }
 

--- a/src/mavrosflight/sensors/imu.cpp
+++ b/src/mavrosflight/sensors/imu.cpp
@@ -36,8 +36,8 @@ void Imu::start_temp_calibration()
 
   measurement_throttle_ = 0;
 
-  A_.clear();
   B_.clear();
+  A_.clear();
 }
 
 bool Imu::calibrate_temp(mavlink_small_imu_t msg)
@@ -57,8 +57,10 @@ bool Imu::calibrate_temp(mavlink_small_imu_t msg)
     {
       Eigen::Vector3d measurement;
       measurement << msg.xacc, msg.yacc, msg.zacc - 9.80665;
-      A_.push_back(measurement);
-      B_.push_back(msg.temperature);
+
+      A_.push_back(msg.temperature);
+      B_.push_back(measurement);
+
       if (msg.temperature < Tmin_)
       {
         Tmin_ = msg.temperature;
@@ -86,16 +88,15 @@ bool Imu::calibrate_temp(mavlink_small_imu_t msg)
       Bmat.resize(B_.size());
 
       // put the data into and Eigen Matrix for linear algebra
-      std::deque<Eigen::Vector3d>::iterator A_it = A_.begin();
-      std::deque<double>::iterator B_it = B_.begin();
+      std::deque<double>::iterator A_it = A_.begin();
+      std::deque<Eigen::Vector3d>::iterator B_it = B_.begin();
       for (int j = 0; j < A_.size(); j++)
       {
-        Eigen::Vector3d temp = *A_it;
-        Amat(j,0) = *B_it;
+        Amat(j,0) = *A_it;
         Amat(j,1) = 1.0;
-        Bmat(j) = temp(i);
-        A_it++;
+        Bmat(j) = (*B_it)(i);
         B_it++;
+        A_it++;
       }
 
       // Perform Least-Squares on the data

--- a/src/mavrosflight/sensors/imu.cpp
+++ b/src/mavrosflight/sensors/imu.cpp
@@ -56,7 +56,7 @@ bool Imu::calibrate_temp(mavlink_small_imu_t msg)
     if (measurement_throttle_ > 20)
     {
       Eigen::Vector3d measurement;
-      measurement << msg.xacc, msg.yacc, msg.zacc - 9.60665; //! \todo need a better way to know the z-axis offset
+      measurement << msg.xacc, msg.yacc, msg.zacc - 9.80665;
       A_.push_back(measurement);
       B_.push_back(msg.temperature);
       if (msg.temperature < Tmin_)


### PR DESCRIPTION
Switch IMU data to floating point. Closes #2.

Before merging, need to test the following:
- [x] parameter get/set interface for both integer and floating point values
- [x] accelerometer calibration, both in fcu_io and in ROSflight

I have to run but can do those tests in about an hour.
