### PR TITLE
added attitude message support

### DIFF
--- a/include/fcu_io.h
+++ b/include/fcu_io.h
@@ -20,6 +20,7 @@
 #include <sensor_msgs/Range.h>
 #include <std_srvs/Trigger.h>
 
+#include <fcu_common/Attitude.h>
 #include <fcu_common/ExtendedCommand.h>
 #include <fcu_common/ServoOutputRaw.h>
 
@@ -53,6 +54,7 @@ private:
   void handle_heartbeat_msg();
   void handle_command_ack_msg(const mavlink_message_t &msg);
   void handle_statustext_msg(const mavlink_message_t &msg);
+  void handle_attitude_msg(const mavlink_message_t &msg);
   void handle_small_imu_msg(const mavlink_message_t &msg);
   void handle_servo_output_raw_msg(const mavlink_message_t &msg);
   void handle_rc_channels_raw_msg(const mavlink_message_t &msg);
@@ -92,6 +94,7 @@ private:
   ros::Publisher temperature_pub_;
   ros::Publisher baro_pub_;
   ros::Publisher sonar_pub_;
+  ros::Publisher attitude_pub_;
   std::map<std::string, ros::Publisher> named_value_int_pubs_;
   std::map<std::string, ros::Publisher> named_value_float_pubs_;
 

--- a/src/fcu_io.cpp
+++ b/src/fcu_io.cpp
@@ -67,6 +67,9 @@ void fcuIO::handle_mavlink_message(const mavlink_message_t &msg)
   case MAVLINK_MSG_ID_STATUSTEXT:
     handle_statustext_msg(msg);
     break;
+  case MAVLINK_MSG_ID_ATTITUDE:
+    handle_attitude_msg(msg);
+    break;
   case MAVLINK_MSG_ID_SMALL_IMU:
     handle_small_imu_msg(msg);
     break;
@@ -177,6 +180,27 @@ void fcuIO::handle_statustext_msg(const mavlink_message_t &msg)
     ROS_DEBUG("[FCU]: %s", c_str);
     break;
   }
+}
+
+void fcuIO::handle_attitude_msg(const mavlink_message_t &msg)
+{
+  mavlink_attitude_t attitude;
+  mavlink_msg_attitude_decode(&msg, &attitude);
+
+  fcu_common::Attitude attitude_msg;
+  attitude_msg.header.stamp = mavrosflight_->time.get_ros_time_ms(attitude.time_boot_ms);
+  attitude_msg.roll = attitude.roll;
+  attitude_msg.pitch = attitude.pitch;
+  attitude_msg.yaw = attitude.yaw;
+  attitude_msg.p = attitude.rollspeed;
+  attitude_msg.q = attitude.pitchspeed;
+  attitude_msg.r = attitude.yawspeed;
+
+  if(attitude_pub_.getTopic().empty())
+  {
+    attitude_pub_ = nh_.advertise<fcu_common::Attitude>("attitude", 1);
+  }
+  attitude_pub_.publish(attitude_msg);
 }
 
 void fcuIO::handle_small_imu_msg(const mavlink_message_t &msg)


### PR DESCRIPTION
I'm proposing this pull request to supersede #35. All it does is cherry-pick the commit that adds attitude message support to clean up the history a bit (rather than adding and then removing HIL support in the process). @superjax are you a fan of this or no?
